### PR TITLE
removing redundant loggregator.v2 declaration where used

### DIFF
--- a/v2/egress.proto
+++ b/v2/egress.proto
@@ -5,7 +5,7 @@ package loggregator.v2;
 import "envelope.proto";
 
 service Egress {
-  rpc Receiver(EgressRequest) returns (stream loggregator.v2.Envelope) {}
+  rpc Receiver(EgressRequest) returns (stream Envelope) {}
 }
 
 message EgressRequest {

--- a/v2/egress_query.proto
+++ b/v2/egress_query.proto
@@ -16,5 +16,5 @@ message ContainerMetricRequest {
 }
 
 message QueryResponse {
-  repeated loggregator.v2.Envelope envelopes = 1;
+  repeated Envelope envelopes = 1;
 }

--- a/v2/ingress.proto
+++ b/v2/ingress.proto
@@ -5,7 +5,7 @@ package loggregator.v2;
 import "envelope.proto";
 
 service Ingress {
-    rpc Sender(stream loggregator.v2.Envelope) returns (IngressResponse) {}
+    rpc Sender(stream Envelope) returns (IngressResponse) {}
     rpc BatchSender(stream EnvelopeBatch) returns (BatchSenderResponse) {}
 }
 
@@ -13,7 +13,7 @@ message IngressResponse {}
 
 
 message EnvelopeBatch {
-    repeated loggregator.v2.Envelope batch = 1;
+    repeated Envelope batch = 1;
 }
 
 message BatchSenderResponse {}


### PR DESCRIPTION
Full path not needed as the package is declared
[#149042729]

Signed-off-by: Wesley Jeanette <wjeanette@pivotal.io>