### PR TITLE
Add java options to proto files

### DIFF
--- a/v2/egress.proto
+++ b/v2/egress.proto
@@ -4,6 +4,9 @@ package loggregator.v2;
 
 import "envelope.proto";
 
+option java_package = "org.cloudfoudry.loggregator.v2";
+option java_outer_classname = "LoggregatorEgress";
+
 service Egress {
   rpc Receiver(EgressRequest) returns (stream Envelope) {}
   rpc BatchedReceiver(EgressBatchRequest) returns (stream EnvelopeBatch) {}

--- a/v2/envelope.proto
+++ b/v2/envelope.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package loggregator.v2;
 
+option java_package = "org.cloudfoudry.loggregator.v2";
+option java_outer_classname = "LoggregatorEnvelope";
+
 message Envelope {
   int64 timestamp = 1;
   string source_id = 2;

--- a/v2/ingress.proto
+++ b/v2/ingress.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package loggregator.v2;
 
+option java_package = "org.cloudfoudry.loggregator.v2";
+option java_outer_classname = "LoggregatorIngress";
+
 import "envelope.proto";
 
 service Ingress {


### PR DESCRIPTION
We'd like to generate gRPC code to consume from loggregator from a Java app for JMX reasons.

The java options we're added are necessary to get a good package and class name in Java.

See:
- https://developers.google.com/protocol-buffers/docs/reference/java-generated#invocation
- https://developers.google.com/protocol-buffers/docs/reference/java-generated#package
For details on these two options.

We've tested generation of the code with the invocation `protoc --proto_path=v2 --java_out=build/gen  v2/*` from the root of the repo.

Thanks!

Signed-off-by: JT Archie <jtarchie@gmail.com> and Milan Klanjsek <mklanjsek@pivotal.io>