### PR TITLE
Remove deprecated tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ require.
 |------------|----------------------------------|
 | timestamp  | envelope.timestamp               |
 | tags       | envelope.tags                    |
-| origin     | envelope.tags['origin'].text     |
-| deployment | envelope.tags['deployment'].text |
-| job        | envelope.tags['job'].text        |
-| index      | envelope.tags['index'].text      |
-| ip         | envelope.tags['ip'].text         |
+| origin     | envelope.tags['origin']          |
+| deployment | envelope.tags['deployment']      |
+| job        | envelope.tags['job']             |
+| index      | envelope.tags['index']           |
+| ip         | envelope.tags['ip']              |
 
 
 #### HttpStartStop
@@ -107,16 +107,16 @@ An *HttpStartStop* envelope is derived from a v2 *Timer* envelope.
 | startTimestamp | timer.start                             |
 | stopTimestamp  | timer.stop                              |
 | applicationId  | envelope.source_id                      |
-| requestId      | envelope.tags['request_id'].text        |
-| peerType       | envelope.tags['peer_type'].text         |
-| method         | envelope.tags['method'].text            |
-| uri            | envelope.tags['uri'].text               |
-| remoteAddress  | envelope.tags['remote_address'].text    |
-| userAgent      | envelope.tags['user_agent'].text        |
-| statusCode     | envelope.tags['status_code'].integer    |
-| contentLength  | envelope.tags['content_length'].integer |
-| instanceIndex  | envelope.tags['instance_index'].integer |
-| forwarded      | envelope.tags['forwarded'].text         |
+| requestId      | envelope.tags['request_id']             |
+| peerType       | envelope.tags['peer_type']              |
+| method         | envelope.tags['method']                 |
+| uri            | envelope.tags['uri']                    |
+| remoteAddress  | envelope.tags['remote_address']         |
+| userAgent      | envelope.tags['user_agent']             |
+| statusCode     | envelope.tags['status_code']            |
+| contentLength  | envelope.tags['content_length']         |
+| instanceIndex  | envelope.tags['instance_index']         |
+| forwarded      | envelope.tags['forwarded']              |
 
 #### LogMessage
 
@@ -128,7 +128,7 @@ A *LogMessage* envelope is derived from a v2 *Log* envelope
 | message_type    | log.type                              |
 | timestamp       | envelope.timestamp                    |
 | app_id          | envelope.source_id                    |
-| source_type     | envelope.tags['source_type'].text     |
+| source_type     | envelope.tags['source_type']          |
 | source_instance | envelope.instance_id                  |
 
 #### CounterEvent

--- a/v2/egress.proto
+++ b/v2/egress.proto
@@ -32,8 +32,8 @@ message EgressRequest {
   // given, no data will be sent.
   repeated Selector selectors = 4;
 
-  // TODO: This can be removed once the envelope.deprecated_tags is removed.
-  bool use_preferred_tags = 3;
+  // Deprecated along with deprecated tags.
+  // bool use_preferred_tags = 3;
 }
 
 message EgressBatchRequest {
@@ -56,8 +56,8 @@ message EgressBatchRequest {
   // given, no data will be sent.
   repeated Selector selectors = 4;
 
-  // TODO: This can be removed once the envelope.deprecated_tags is removed.
-  bool use_preferred_tags = 3;
+  // Deprecated along with deprecated tags.
+  // bool use_preferred_tags = 3;
 }
 
 // Selector instructs Loggregator to only send envelopes that match the given

--- a/v2/envelope.proto
+++ b/v2/envelope.proto
@@ -9,8 +9,10 @@ message Envelope {
   int64 timestamp = 1;
   string source_id = 2 [json_name="source_id"];
   string instance_id = 8 [json_name="instance_id"];
-  map<string, Value> deprecated_tags = 3 [json_name="deprecated_tags"];
   map<string, string> tags = 9;
+
+  // Deprecated in favor of tags
+  // map<string, Value> deprecated_tags = 3 [json_name="deprecated_tags"];
 
   oneof message {
     Log log = 4;


### PR DESCRIPTION
Prior to merging this we should audit the other CF components or users of loggregator to ensure they are not still using `DeprecatedTags`. Upon merging we should update the `go-loggregator` clients and all the projects that use that client.