### PR TITLE
Update go package to include version number for go-loggregator

### DIFF
--- a/v2/egress.proto
+++ b/v2/egress.proto
@@ -4,7 +4,7 @@ package loggregator.v2;
 
 import "loggregator-api/v2/envelope.proto";
 
-option go_package = "code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2";
+option go_package = "code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2";
 
 option java_package = "org.cloudfoundry.loggregator.v2";
 option java_outer_classname = "LoggregatorEgress";

--- a/v2/envelope.proto
+++ b/v2/envelope.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package loggregator.v2;
 
-option go_package = "code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2";
+option go_package = "code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2";
 
 option java_package = "org.cloudfoundry.loggregator.v2";
 option java_outer_classname = "LoggregatorEnvelope";

--- a/v2/ingress.proto
+++ b/v2/ingress.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package loggregator.v2;
 
-option go_package = "code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2";
+option go_package = "code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2";
 
 option java_package = "org.cloudfoundry.loggregator.v2";
 option java_outer_classname = "LoggregatorIngress";


### PR DESCRIPTION
This makes the import correct in generated go code from proto files that import go-loggregator rpc. (i.e. go-log-cache)