### PR TITLE
loggregator_v2: Bump go-loggregator major version to v10

### DIFF
--- a/v2/egress.proto
+++ b/v2/egress.proto
@@ -4,7 +4,7 @@ package loggregator.v2;
 
 import "loggregator-api/v2/envelope.proto";
 
-option go_package = "code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2";
+option go_package = "code.cloudfoundry.org/go-loggregator/v10/rpc/loggregator_v2";
 
 option java_package = "org.cloudfoundry.loggregator.v2";
 option java_outer_classname = "LoggregatorEgress";

--- a/v2/envelope.proto
+++ b/v2/envelope.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package loggregator.v2;
 
-option go_package = "code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2";
+option go_package = "code.cloudfoundry.org/go-loggregator/v10/rpc/loggregator_v2";
 
 option java_package = "org.cloudfoundry.loggregator.v2";
 option java_outer_classname = "LoggregatorEnvelope";

--- a/v2/ingress.proto
+++ b/v2/ingress.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package loggregator.v2;
 
-option go_package = "code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2";
+option go_package = "code.cloudfoundry.org/go-loggregator/v10/rpc/loggregator_v2";
 
 option java_package = "org.cloudfoundry.loggregator.v2";
 option java_outer_classname = "LoggregatorIngress";


### PR DESCRIPTION
Bumps go-loggregator major version to v10 to reflect the switch from `grpc.Dial` to `grpc.NewClient`, which is a breaking change because of the different DialOptions that are offered.